### PR TITLE
Create LaravelGenerator.php

### DIFF
--- a/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
+++ b/src/Mpociot/ApiDoc/Generators/LaravelGenerator.php
@@ -140,10 +140,10 @@ class LaravelGenerator extends AbstractGenerator
 
         $kernel->terminate($request, $response);
 
-        if (file_exists($file = App::bootstrapPath().'/app.php')) {
-            $app = require $file;
-            $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
-        }
+//         if (file_exists($file = App::bootstrapPath().'/app.php')) {
+//             $app = require $file;
+//             $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+//         }
 
         return $response;
     }


### PR DESCRIPTION
commented this blocks works with Laravel 5.4.26 with Passport Guard
I have successful authenticated response with following command
`php artisan api:generate --routePrefix="api/*" --header 'Authorization: Bearer c8b10ace7d1ccaa21c38fef6d9c5a1716d4abeb2f25e95d9f377dc6eeab0d59510a43dbac23c8ca2' --force --useMiddlewares --actAsUserId=2`
if (file_exists($file = App::bootstrapPath().'/app.php')) {
//            $app = require $file;
//            $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
//        }